### PR TITLE
Make `shutdown_on_signal` only available on Unix

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -497,7 +497,7 @@ impl JobLocked {
     /// This is checked if it is running only after 500ms in 500ms intervals.
     /// ```rust,ignore
     /// let mut sched = JobScheduler::new();
-    /// let job = Job::new_repeated(Duration::from_secs(8), |_uuid, _lock| Box::pin(async move {
+    /// let job = Job::new_repeated_async(Duration::from_secs(8), |_uuid, _lock| Box::pin(async move {
     ///     println!("{:?} I'm repeated every 8 seconds", chrono::Utc::now());
     /// }));
     /// sched.add(job)

--- a/src/job_scheduler.rs
+++ b/src/job_scheduler.rs
@@ -354,7 +354,8 @@ impl JobsSchedulerLocked {
         r.get(job_id).await.map(|v| {
             v.map(|vv| vv.next_tick)
                 .filter(|t| *t != 0)
-                .map(|ts| NaiveDateTime::from_timestamp(ts as i64, 0))
+                .map(|ts| NaiveDateTime::from_timestamp_opt(ts as i64, 0)
+                    .expect("invalid or out-of-range datetime"))
                 .map(|ts| DateTime::from_utc(ts, Utc))
         })
     }

--- a/src/job_scheduler.rs
+++ b/src/job_scheduler.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-#[cfg(feature = "signal")]
+#[cfg(all(unix, feature = "signal"))]
 use tokio::signal::unix::SignalKind;
 use tokio::sync::RwLock;
 use tracing::{error, info};
@@ -377,7 +377,7 @@ impl JobsSchedulerLocked {
 
     ///
     /// Wait for a signal to shut the runtime down with
-    #[cfg(feature = "signal")]
+    #[cfg(all(unix, feature = "signal"))]
     pub fn shutdown_on_signal(&self, signal: SignalKind) {
         let mut l = self.clone();
         tokio::spawn(async move {


### PR DESCRIPTION
Fixes the compilation error on Windows due to `tokio::signal::unix::SignalKind` only being available on Unix systems. Should fix #36.

As a bonus, I have also fixed the following deprecation warning:
> use of deprecated associated function `chrono::NaiveDateTime::from_timestamp`: use `from_timestamp_opt()` instead