### PR TITLE
Added additional feature to allow to use log crate instead of tracing crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ nats_storage = ["nats", "has_bytes" ]
 postgres_storage = ["tokio-postgres", "has_bytes" ]
 postgres_native_tls = ["postgres_storage", "postgres-native-tls" ]
 postgres_openssl = ["postgres_storage", "postgres-openssl" ]
+log = ["tracing/log", "tracing/log-always"]
 
 default = []
 


### PR DESCRIPTION
The `tracing` crate is great for logging asynchronous applications, however it requires an extra overhead on the application startup to set up the traces endpoints.
Some applications which use this library do not set up the tracing endpoint, and this can make the error logs invisible for the library users.
In contrast the `log` crate is fairly easy to set up, however it does not perform so good in asynchronous context.
The tracing library has a `log-always` feature which write logs of all the traces, allowing the errors to be visible for both, tracing library users and log library users.

This pull request adds a new feature to this crate, the `log` feature. When this feature is used, it will set the `log-always` feature in the tracing crate, so the users of the log library are able to watch errors in the library.