### PR TITLE
Update num-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }
 
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.4"
 
 [dependencies.nats]
 version = "0.24.1"


### PR DESCRIPTION
Updates to newer num-derive and thereby to syn 2, which may end up saving a lot
of projects some compile time.
