### PR TITLE
fix(postgres): fix a typo in a `time_till_next_job` SQL query

### DIFF
--- a/src/postgres/metadata_store.rs
+++ b/src/postgres/metadata_store.rs
@@ -428,8 +428,8 @@ impl MetaDataStorage for PostgresMetadataStore {
                         + &*table
                         + " \
                         WHERE \
-                              next_tick > 0\
-                          AND next_tick > $2 \
+                              next_tick > 0 \
+                          AND next_tick > $1 \
                         ORDER BY next_tick ASC \
                         LIMIT 1";
                     let row = store.query(&*sql, &[&now]).await;


### PR DESCRIPTION
## Summary

This PR fixes two small typos in the SQL query that powers `time_till_next_job` methods of the Postgres metadata store (missing space and wrong SQL parameter index).