### PR TITLE
Cron schedule pattern no longer supports pattern for year

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Creating a schedule for a job is done using any `ToString` impl, leveraging the
 The scheduling format is as follows:
 
 ```text
-sec   min   hour   day of month   month   day of week   year
-*     *     *      *              *       *             *
+sec   min   hour   day of month   month   day of week
+*     *     *      *              *       *
 ```
 
 Time is specified for `UTC` and not your local timezone. Note that the year may


### PR DESCRIPTION
The upstream [pattern matching](https://github.com/Hexagon/croner-rust?tab=readme-ov-file#pattern) no longer recognizes year. Removing it from the example pattern in the README.