### PR TITLE
Vibe coded fix for job schedule DST transitions

### DIFF
--- a/proto/job.proto
+++ b/proto/job.proto
@@ -45,7 +45,7 @@ message JobStoredData {
   bytes extra = 9;
   bool ran = 10;
   bool stopped = 11;
-  int32 time_offset_seconds = 12;
+  string timezone_id = 12;
 }
 
 message JobIdAndNotification {

--- a/src/job/cron_job.rs
+++ b/src/job/cron_job.rs
@@ -121,6 +121,6 @@ impl Job for CronJob {
     }
 
     fn fixed_offset_west(&self) -> i32 {
-        self.data.time_offset_seconds
+        self.data.get_current_offset()
     }
 }

--- a/src/job/job_data.rs
+++ b/src/job/job_data.rs
@@ -24,7 +24,7 @@ pub struct JobStoredData {
     pub ran: bool,
     pub stopped: bool,
     pub job: ::core::option::Option<job_stored_data::Job>,
-    pub time_offset_seconds: i32,
+    pub timezone_id: String,
 }
 
 /// Nested message and enum types in `JobStoredData`.

--- a/src/job/job_data_prost.rs
+++ b/src/job/job_data_prost.rs
@@ -38,8 +38,8 @@ pub struct JobStoredData {
     pub ran: bool,
     #[prost(bool, tag = "11")]
     pub stopped: bool,
-    #[prost(int32, tag = "12")]
-    pub time_offset_seconds: i32,
+    #[prost(string, tag = "12")]
+    pub timezone_id: ::prost::alloc::string::String,
     #[prost(oneof = "job_stored_data::Job", tags = "6, 7")]
     pub job: ::core::option::Option<job_stored_data::Job>,
 }

--- a/src/job/non_cron_job.rs
+++ b/src/job/non_cron_job.rs
@@ -134,6 +134,6 @@ impl Job for NonCronJob {
     }
 
     fn fixed_offset_west(&self) -> i32 {
-        self.data.time_offset_seconds
+        self.data.get_current_offset()
     }
 }


### PR DESCRIPTION
Partial fix for
https://github.com/mvniekerk/tokio-cron-scheduler/issues/107. Seems to work correctly now when specifying timezones by name, but not with `Local`. Also, storing the timezone as a string can probably be improved.