### PR TITLE
Add support for optional seconds in cron expressions

### DIFF
--- a/src/job/builder.rs
+++ b/src/job/builder.rs
@@ -8,7 +8,7 @@ use crate::job::job_data_prost;
 #[cfg(feature = "has_bytes")]
 pub use crate::job::job_data_prost::{JobStoredData, JobType, Uuid};
 use crate::job::{JobLocked, nop, nop_async};
-use crate::{JobSchedulerError, JobToRun, JobToRunAsync};
+use crate::{JobSchedulerError, JobToRun, JobToRunAsync, SecondsMode};
 use chrono::{Offset, TimeZone, Utc};
 use core::time::Duration;
 use croner::Cron;
@@ -28,6 +28,7 @@ pub struct JobBuilder<T> {
     pub duration: Option<Duration>,
     pub repeating: Option<bool>,
     pub instant: Option<Instant>,
+    pub seconds_mode: SecondsMode,
 }
 
 impl JobBuilder<Utc> {
@@ -42,6 +43,7 @@ impl JobBuilder<Utc> {
             duration: None,
             repeating: None,
             instant: None,
+            seconds_mode: SecondsMode::Required,
         }
     }
 }
@@ -58,12 +60,25 @@ impl<T: TimeZone> JobBuilder<T> {
             duration: self.duration,
             repeating: self.repeating,
             instant: self.instant,
+            seconds_mode: self.seconds_mode,
         }
     }
 
     pub fn with_job_id(self, job_id: Uuid) -> Self {
         Self {
             job_id: Some(job_id),
+            ..self
+        }
+    }
+
+    /// Configure how the seconds field is handled in cron expressions.
+    ///
+    /// - `SecondsMode::Required` (default): 6-field expressions required (e.g., "0 */5 * * * *")
+    /// - `SecondsMode::Optional`: 5 or 6 field expressions accepted (e.g., "*/5 * * * *" or "0 */5 * * * *")
+    /// - `SecondsMode::Disallowed`: Only 5-field expressions accepted (e.g., "*/5 * * * *")
+    pub fn with_seconds_mode(self, seconds_mode: SecondsMode) -> Self {
+        Self {
+            seconds_mode,
             ..self
         }
     }
@@ -100,9 +115,10 @@ impl<T: TimeZone> JobBuilder<T> {
     where
         TS: ToString,
     {
-        let schedule = JobLocked::schedule_to_cron(schedule)?;
+        let seconds: croner::parser::Seconds = self.seconds_mode.into();
+        let schedule = JobLocked::schedule_to_cron_with_seconds_mode(schedule, seconds)?;
         let schedule = CronParser::builder()
-            .seconds(croner::parser::Seconds::Required)
+            .seconds(seconds)
             .build()
             .parse(&schedule)
             .map_err(|_| JobSchedulerError::ParseSchedule)?;
@@ -222,7 +238,7 @@ impl<T: TimeZone> JobBuilder<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::JobScheduler;
+    use crate::{JobScheduler, SecondsMode};
     use chrono::Timelike;
 
     #[tokio::test]
@@ -252,5 +268,116 @@ mod test {
         let paris_time = next_tick.with_timezone(&chrono_tz::Europe::Paris);
         assert_eq!(paris_time.hour(), 9);
         assert_eq!(paris_time.minute(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_five_field_cron_with_optional_seconds() {
+        // 5-field expression should work with SecondsMode::Optional
+        let mut scheduler = JobScheduler::new().await.unwrap();
+
+        let job_id = scheduler
+            .add(
+                JobBuilder::new()
+                    .with_cron_job_type()
+                    .with_seconds_mode(SecondsMode::Optional)
+                    .with_schedule("30 9 * * *") // 5-field: minute hour dom month dow
+                    .unwrap()
+                    .with_run_async(Box::new(|_uuid, _lock| Box::pin(async move {})))
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let next_tick = scheduler
+            .next_tick_for_job(job_id)
+            .await
+            .unwrap()
+            .expect("Should have next_tick");
+
+        // Should run at minute 30, hour 9
+        assert_eq!(next_tick.minute(), 30);
+        assert_eq!(next_tick.hour(), 9);
+    }
+
+    #[tokio::test]
+    async fn test_five_field_cron_fails_with_required_seconds() {
+        // 5-field expression should fail with default SecondsMode::Required
+        let result = JobBuilder::new()
+            .with_cron_job_type()
+            .with_schedule("30 9 * * *"); // 5-field without setting Optional
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_six_field_cron_works_with_optional_seconds() {
+        // 6-field expression should still work with SecondsMode::Optional
+        let mut scheduler = JobScheduler::new().await.unwrap();
+
+        let job_id = scheduler
+            .add(
+                JobBuilder::new()
+                    .with_cron_job_type()
+                    .with_seconds_mode(SecondsMode::Optional)
+                    .with_schedule("0 30 9 * * *") // 6-field with seconds
+                    .unwrap()
+                    .with_run_async(Box::new(|_uuid, _lock| Box::pin(async move {})))
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let next_tick = scheduler
+            .next_tick_for_job(job_id)
+            .await
+            .unwrap()
+            .expect("Should have next_tick");
+
+        assert_eq!(next_tick.second(), 0);
+        assert_eq!(next_tick.minute(), 30);
+        assert_eq!(next_tick.hour(), 9);
+    }
+
+    #[tokio::test]
+    async fn test_five_field_cron_works_with_disallowed_seconds() {
+        // 5-field expression should work with SecondsMode::Disallowed
+        let mut scheduler = JobScheduler::new().await.unwrap();
+
+        let job_id = scheduler
+            .add(
+                JobBuilder::new()
+                    .with_cron_job_type()
+                    .with_seconds_mode(SecondsMode::Disallowed)
+                    .with_schedule("30 9 * * *") // 5-field: minute hour dom month dow
+                    .unwrap()
+                    .with_run_async(Box::new(|_uuid, _lock| Box::pin(async move {})))
+                    .build()
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let next_tick = scheduler
+            .next_tick_for_job(job_id)
+            .await
+            .unwrap()
+            .expect("Should have next_tick");
+
+        // Should run at minute 30, hour 9
+        assert_eq!(next_tick.minute(), 30);
+        assert_eq!(next_tick.hour(), 9);
+    }
+
+    #[tokio::test]
+    async fn test_six_field_cron_fails_with_disallowed_seconds() {
+        // 6-field expression should fail with SecondsMode::Disallowed
+        let result = JobBuilder::new()
+            .with_cron_job_type()
+            .with_seconds_mode(SecondsMode::Disallowed)
+            .with_schedule("0 30 9 * * *"); // 6-field should be rejected
+
+        assert!(result.is_err());
     }
 }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -3,7 +3,7 @@ use crate::job::job_data::{JobState, JobType};
 #[cfg(feature = "has_bytes")]
 use crate::job::job_data_prost::{JobState, JobType};
 use crate::job_scheduler::JobsSchedulerLocked;
-use crate::{JobScheduler, JobSchedulerError, JobStoredData};
+use crate::{JobScheduler, JobSchedulerError, JobStoredData, SecondsMode};
 use chrono::{DateTime, Offset, TimeZone, Utc};
 use cron_job::CronJob;
 use croner::Cron;
@@ -88,6 +88,9 @@ pub trait Job {
 impl JobLocked {
     /// Create a new cron job.
     ///
+    /// This requires a 6-field cron expression with seconds (e.g., `"0 30 9 * * *"`).
+    /// To also allow parsing 5-field expressions without seconds, use [`Job::new_with_opt_seconds`].
+    ///
     /// ```rust,ignore
     /// let mut sched = JobScheduler::new();
     /// // Run at second 0 of the 15th minute of the 6th, 8th, and 10th hour
@@ -107,13 +110,36 @@ impl JobLocked {
         Self::new_tz(schedule, Utc, run)
     }
 
+    /// Create a new cron job that accepts both 5-field and 6-field cron expressions.
+    ///
+    /// ```rust,ignore
+    /// let mut sched = JobScheduler::new();
+    /// // Run every 5 minutes using standard crontab format (5-field)
+    /// let job = Job::new_with_opt_seconds("*/5 * * * *", |_uuid, _lock| {
+    ///             println!("{:?} Hi I ran", chrono::Utc::now());
+    ///         });
+    /// sched.add(job)
+    /// tokio::spawn(sched.start());
+    /// ```
+    pub fn new_with_opt_seconds<S, T>(schedule: S, run: T) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) + Send + Sync,
+        S: ToString,
+    {
+        Self::new_tz_with_opt_seconds(schedule, Utc, run)
+    }
+
     /// Create a new cron job at a timezone.
+    ///
+    /// This requires a 6-field cron expression with seconds (e.g., `"0 30 9 * * *"`).
+    /// To also allow parsing 5-field expressions without seconds, use [`Job::new_tz_with_opt_seconds`].
     ///
     /// ```rust,ignore
     /// let mut sched = JobScheduler::new();
     /// // Run at second 0 of the 15th minute of the 6th, 8th, and 10th hour
     /// // of any day in March and June that is a Friday of the year 2017.
-    /// let job = Job::new("0 15 6,8,10 * Mar,Jun Fri 2017", |_uuid, _lock| {
+    /// let job = Job::new_tz("0 15 6,8,10 * Mar,Jun Fri 2017", Utc, |_uuid, _lock| {
     ///             println!("{:?} Hi I ran", chrono::Utc::now());
     ///         });
     /// sched.add(job)
@@ -126,13 +152,54 @@ impl JobLocked {
         S: ToString,
         TZ: TimeZone,
     {
-        let schedule = Self::schedule_to_cron(schedule)?;
+        Self::new_tz_with_seconds_mode(schedule, timezone, SecondsMode::Required, run)
+    }
+
+    /// Create a new cron job at a timezone that accepts both 5-field and 6-field cron expressions.
+    ///
+    /// ```rust,ignore
+    /// let mut sched = JobScheduler::new();
+    /// // Run at the 15th minute of the 6th, 8th, and 10th hour (5-field crontab format)
+    /// let job = Job::new_tz_with_opt_seconds("15 6,8,10 * * *", Utc, |_uuid, _lock| {
+    ///             println!("{:?} Hi I ran", chrono::Utc::now());
+    ///         });
+    /// sched.add(job)
+    /// tokio::spawn(sched.start());
+    /// ```
+    pub fn new_tz_with_opt_seconds<S, T, TZ>(
+        schedule: S,
+        timezone: TZ,
+        run: T,
+    ) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) + Send + Sync,
+        S: ToString,
+        TZ: TimeZone,
+    {
+        Self::new_tz_with_seconds_mode(schedule, timezone, SecondsMode::Optional, run)
+    }
+
+    fn new_tz_with_seconds_mode<S, T, TZ>(
+        schedule: S,
+        timezone: TZ,
+        seconds_mode: SecondsMode,
+        run: T,
+    ) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) + Send + Sync,
+        S: ToString,
+        TZ: TimeZone,
+    {
+        let seconds: croner::parser::Seconds = seconds_mode.into();
+        let schedule = Self::schedule_to_cron_with_seconds_mode(schedule, seconds)?;
         let time_offset_seconds = timezone
             .offset_from_utc_datetime(&Utc::now().naive_local())
             .fix()
             .local_minus_utc();
         let schedule = CronParser::builder()
-            .seconds(croner::parser::Seconds::Required)
+            .seconds(seconds)
             .dom_and_dow(true)
             .build()
             .parse(&schedule)
@@ -172,6 +239,9 @@ impl JobLocked {
 
     /// Create a new async cron job.
     ///
+    /// This requires a 6-field cron expression with seconds (e.g., `"0 30 9 * * *"`).
+    /// To also allow parsing 5-field expressions without seconds, use [`Job::new_async_with_opt_seconds`].
+    ///
     /// ```rust,ignore
     /// let mut sched = JobScheduler::new();
     /// // Run at second 0 of the 15th minute of the 6th, 8th, and 10th hour
@@ -193,7 +263,32 @@ impl JobLocked {
         Self::new_async_tz(schedule, Utc, run)
     }
 
+    /// Create a new async cron job that accepts both 5-field and 6-field cron expressions.
+    ///
+    /// ```rust,ignore
+    /// let mut sched = JobScheduler::new();
+    /// // Run every 5 minutes using standard crontab format (5-field)
+    /// let job = Job::new_async_with_opt_seconds("*/5 * * * *", |_uuid, _lock| Box::pin( async move {
+    ///             println!("{:?} Hi I ran", chrono::Utc::now());
+    ///         }));
+    /// sched.add(job)
+    /// tokio::spawn(sched.start());
+    /// ```
+    pub fn new_async_with_opt_seconds<S, T>(schedule: S, run: T) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) -> Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync,
+        S: ToString,
+    {
+        Self::new_async_tz_with_opt_seconds(schedule, Utc, run)
+    }
+
     /// Create a new async cron job at a timezone.
+    ///
+    /// This requires a 6-field cron expression with seconds (e.g., `"0 30 9 * * *"`).
+    /// To also allow parsing 5-field expressions without seconds, use [`Job::new_async_tz_with_opt_seconds`].
     ///
     /// ```rust,ignore
     /// let mut sched = JobScheduler::new();
@@ -218,13 +313,58 @@ impl JobLocked {
         S: ToString,
         TZ: TimeZone,
     {
-        let schedule = Self::schedule_to_cron(schedule)?;
+        Self::new_async_tz_with_seconds_mode(schedule, timezone, SecondsMode::Required, run)
+    }
+
+    /// Create a new async cron job at a timezone that accepts both 5-field and 6-field cron expressions.
+    ///
+    /// ```rust,ignore
+    /// let mut sched = JobScheduler::new();
+    /// // Run at the 15th minute of the 6th, 8th, and 10th hour (5-field crontab format)
+    /// let job = Job::new_async_tz_with_opt_seconds("15 6,8,10 * * *", Utc, |_uuid, _lock| Box::pin( async move {
+    ///             println!("{:?} Hi I ran", chrono::Utc::now());
+    ///         }));
+    /// sched.add(job)
+    /// tokio::spawn(sched.start());
+    /// ```
+    pub fn new_async_tz_with_opt_seconds<S, T, TZ>(
+        schedule: S,
+        timezone: TZ,
+        run: T,
+    ) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) -> Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync,
+        S: ToString,
+        TZ: TimeZone,
+    {
+        Self::new_async_tz_with_seconds_mode(schedule, timezone, SecondsMode::Optional, run)
+    }
+
+    fn new_async_tz_with_seconds_mode<S, T, TZ>(
+        schedule: S,
+        timezone: TZ,
+        seconds_mode: SecondsMode,
+        run: T,
+    ) -> Result<Self, JobSchedulerError>
+    where
+        T: 'static,
+        T: FnMut(Uuid, JobsSchedulerLocked) -> Pin<Box<dyn Future<Output = ()> + Send>>
+            + Send
+            + Sync,
+        S: ToString,
+        TZ: TimeZone,
+    {
+        let seconds: croner::parser::Seconds = seconds_mode.into();
+        let schedule = Self::schedule_to_cron_with_seconds_mode(schedule, seconds)?;
         let time_offset_seconds = timezone
             .offset_from_utc_datetime(&Utc::now().naive_local())
             .fix()
             .local_minus_utc();
         let schedule = CronParser::builder()
-            .seconds(croner::parser::Seconds::Required)
+            .seconds(seconds)
             .dom_and_dow(true)
             .build()
             .parse(&schedule)
@@ -889,11 +1029,27 @@ impl JobLocked {
         Ok(schedule.to_string())
     }
 
+    #[cfg(not(feature = "english"))]
+    pub(crate) fn schedule_to_cron_with_seconds_mode<T: ToString>(
+        schedule: T,
+        _seconds: croner::parser::Seconds,
+    ) -> Result<String, JobSchedulerError> {
+        Ok(schedule.to_string())
+    }
+
     #[cfg(feature = "english")]
     pub fn schedule_to_cron<T: ToString>(schedule: T) -> Result<String, JobSchedulerError> {
+        Self::schedule_to_cron_with_seconds_mode(schedule, croner::parser::Seconds::Required)
+    }
+
+    #[cfg(feature = "english")]
+    pub(crate) fn schedule_to_cron_with_seconds_mode<T: ToString>(
+        schedule: T,
+        seconds: croner::parser::Seconds,
+    ) -> Result<String, JobSchedulerError> {
         let schedule = schedule.to_string();
         match CronParser::builder()
-            .seconds(croner::parser::Seconds::Required)
+            .seconds(seconds)
             .dom_and_dow(true)
             .build()
             .parse(&schedule)
@@ -1032,5 +1188,57 @@ mod test {
 
         // Should be the same UTC time
         assert_eq!(utc_next, shanghai_next);
+    }
+
+    #[tokio::test]
+    async fn test_new_async_tz_with_opt_seconds() {
+        let mut scheduler = JobScheduler::new().await.unwrap();
+
+        let job_id = scheduler
+            .add(
+                JobLocked::new_async_tz_with_opt_seconds(
+                    "30 9 * * *", // 5-field format, starting with minutes
+                    chrono_tz::Europe::Paris,
+                    |_uuid, _lock| Box::pin(async move {}),
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let next_tick = scheduler
+            .next_tick_for_job(job_id)
+            .await
+            .unwrap()
+            .expect("Should have next_tick");
+
+        let paris_time = next_tick.with_timezone(&chrono_tz::Europe::Paris);
+        assert_eq!(paris_time.hour(), 9);
+        assert_eq!(paris_time.minute(), 30);
+    }
+
+    #[tokio::test]
+    async fn test_new_with_opt_seconds() {
+        let mut scheduler = JobScheduler::new().await.unwrap();
+
+        let job_id = scheduler
+            .add(
+                JobLocked::new_with_opt_seconds(
+                    "*/5 * * * *", // Every 5 minutes, standard crontab format
+                    |_uuid, _lock| {},
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let next_tick = scheduler
+            .next_tick_for_job(job_id)
+            .await
+            .unwrap()
+            .expect("Should have next_tick");
+
+        // Minute should be divisible by 5
+        assert_eq!(next_tick.minute() % 5, 0);
     }
 }

--- a/src/job_scheduler.rs
+++ b/src/job_scheduler.rs
@@ -8,7 +8,7 @@ use crate::simple::{
     SimpleJobCode, SimpleMetadataStore, SimpleNotificationCode, SimpleNotificationStore,
 };
 use crate::store::{MetaDataStorage, NotificationStore};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -368,10 +368,7 @@ impl JobsSchedulerLocked {
                 if vv.next_tick == 0 {
                     return None;
                 }
-                match NaiveDateTime::from_timestamp_opt(vv.next_tick as i64, 0) {
-                    None => None,
-                    Some(ts) => Some(DateTime::from_naive_utc_and_offset(ts, Utc)),
-                }
+                DateTime::from_timestamp(vv.next_tick as i64, 0)
             } else {
                 None
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,29 @@ use crate::job::job_data_prost::ListOfUuids;
 use chrono::{DateTime, Utc};
 use croner::Cron;
 use croner::parser::CronParser;
+
+/// Configure how the seconds field is handled in cron expressions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SecondsMode {
+    /// 6-field expressions required (e.g., "0 */5 * * * *").
+    /// This is the default for backward compatibility.
+    #[default]
+    Required,
+    /// 5 or 6 field expressions accepted (e.g., "*/5 * * * *" or "0 */5 * * * *").
+    Optional,
+    /// Only 5-field expressions accepted (e.g., "*/5 * * * *").
+    Disallowed,
+}
+
+impl From<SecondsMode> for croner::parser::Seconds {
+    fn from(mode: SecondsMode) -> Self {
+        match mode {
+            SecondsMode::Required => croner::parser::Seconds::Required,
+            SecondsMode::Optional => croner::parser::Seconds::Optional,
+            SecondsMode::Disallowed => croner::parser::Seconds::Disallowed,
+        }
+    }
+}
 #[cfg(not(feature = "has_bytes"))]
 use job::job_data::{JobAndNextTick, JobStoredData, Uuid as JobUuid};
 #[cfg(feature = "has_bytes")]
@@ -123,7 +146,7 @@ impl JobStoredData {
             })
             .and_then(|s| {
                 CronParser::builder()
-                    .seconds(croner::parser::Seconds::Required)
+                    .seconds(croner::parser::Seconds::Optional)
                     .dom_and_dow(true)
                     .build()
                     .parse(s)


### PR DESCRIPTION
## Summary

Adds support for standard 5-field crontab expressions, addressing user friction when using cron expressions generated by tools like crontab.guru.

Closes #111

## Problem

The library currently requires 6-field cron expressions with a seconds field (e.g., `"0 */5 * * * *"`). This creates friction for users who want to use standard 5-field crontab syntax (e.g., `"*/5 * * * *"`), which is the format produced by most cron expression tools and documentation.

## Solution

Introduces a `SecondsMode` enum with three variants:
- **`Required`** (default): 6-field expressions only - preserves backward compatibility
- **`Optional`**: Accepts both 5-field and 6-field expressions
- **`Disallowed`**: 5-field expressions only

The choice to expose a _new_ enum rather than re-exporting [`croner::parser::Seconds`](https://docs.rs/croner/latest/croner/parser/enum.Seconds.html) is to avoid coupling the public API to a dependency.

### New convenience methods

```rust
// 5-field crontab syntax now works
let job = Job::new_with_opt_seconds("*/5 * * * *", |_uuid, _lock| {
    println!("Runs every 5 minutes");
})?;

// Also available with timezone support
let job = Job::new_async_tz_with_opt_seconds("30 9 * * *", chrono_tz::Europe::Paris, |_uuid, _lock| {
    Box::pin(async move { /* ... */ })
})?;
```

### JobBuilder support

```rust
let job = JobBuilder::new()
    .with_cron_job_type()
    .with_seconds_mode(SecondsMode::Optional)
    .with_schedule("*/5 * * * *")?
    .with_run_async(Box::new(|_uuid, _lock| Box::pin(async move {})))
    .build()?;
```

## Changes

- Add `SecondsMode` enum to `src/lib.rs`
- Add `new_with_opt_seconds`, `new_tz_with_opt_seconds`, `new_async_with_opt_seconds`, `new_async_tz_with_opt_seconds` methods
- Add `with_seconds_mode()` to `JobBuilder`
- Update `schedule_to_cron` to support configurable seconds mode
- Add unit tests for all new functionality
- Fix deprecated `NaiveDateTime::from_timestamp_opt` usage

## Backward Compatibility

Fully backward compatible - all existing code continues to work unchanged. The default behavior remains 6-field expressions with required seconds.
