### PR TITLE
fix repeated jobs stopping due to next_tick drifting into the past

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -193,10 +193,16 @@ impl Scheduler {
                                     }
                                     JobType::OneShot => None,
                                     JobType::Repeated => repeated_every.and_then(|r| {
-                                        next_tick.and_then(|nt| {
-                                            nt.checked_add_signed(chrono::Duration::seconds(
-                                                r as i64,
-                                            ))
+                                        next_tick.and_then(|mut nt| {
+                                            let step = chrono::Duration::seconds(r as i64);
+
+                                            // catch up until next_tick is strictly in
+                                            // the future
+                                            while nt <= now {
+                                                nt = nt.checked_add_signed(step)?;
+                                            }
+
+                                            Some(nt)
                                         })
                                     }),
                                 };


### PR DESCRIPTION
Repeated jobs could stop firing permanently because next_tick was computed as (previous_next_tick + interval). When the scheduler loop was delayed or the system was under load, previous_next_tick could already be in the past, causing new next_tick values that were < last_tick or < now.

The must_run logic then permanently excluded the job, leading to repeated jobs that ran a few times and then never again.

This patch adds a catch-up loop for JobType::Repeated, ensuring that next_tick is always in the future.

fixes #113